### PR TITLE
Made 1 the default for num_workers if the user doesn't set it

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -100,7 +100,7 @@ class ComputeZCoreScores(foo.Operator):
         model = ctx.params.get("model")
         model = foz.load_zoo_model(model) if model else None
         batch_size = ctx.params.get("batch_size", None)
-        num_workers = ctx.params.get("num_workers", None)
+        num_workers = ctx.params.get("num_workers") or 1
         skip_failures = ctx.params.get("skip_failures", True)
         coreset_size = ctx.params["coreset_size"]
 


### PR DESCRIPTION
Error when user does not set `num_workers` in the input form. This fixes that

Traceback (most recent call last):
  File "/opt/fiftyone-teams-app/lib/python3.11/site-packages/fiftyone/operators/delegated.py", line 99, in _execute_operator_in_child_process
    result = asyncio.run(service._execute_operator(operation))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/opt/fiftyone-teams-app/lib/python3.11/site-packages/fiftyone/operators/delegated.py", line 983, in _execute_operator
    result = await do_execute_operator(operator, ctx, exhaust=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/fiftyone-teams-app/lib/python3.11/site-packages/fiftyone/operators/executor.py", line 537, in do_execute_operator
    result = await (
             ^^^^^^^
  File "/opt/fiftyone-teams-app/lib/python3.11/site-packages/fiftyone/core/utils.py", line 3156, in run_sync_task
    return await loop.run_in_executor(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/fiftyone-teams-app/lib/python3.11/site-packages/fiftyone/core/utils.py", line 3157, in <lambda>
    _get_sync_task_executor(), lambda: ctx.run(func, *args)
                                       ^^^^^^^^^^^^^^^^^^^^
  File "/opt/plugins/@51labs/zero-shot-coreset-selection/__init__.py", line 120, in execute
    scores = zcore.zcore_scores(
             ^^^^^^^^^^^^^^^^^^^
  File "/opt/plugins/@51labs/zero-shot-coreset-selection/zcore.py", line 24, in zcore_scores
    if use_multiprocessing and num_workers > 1:
                               ^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'NoneType' and 'int'