### PR TITLE
Add community badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
 # zero-shot-coreset-selection
+
+<div align="center">
+
+[![Discord](https://img.shields.io/badge/Discord-7289DA?logo=discord&logoColor=white)](https://discord.gg/fiftyone-community)
+[![Hugging Face](https://img.shields.io/badge/Hugging_Face-purple?style=flat&logo=huggingface)](https://huggingface.co/Voxel51)
+[![Voxel51 Blog](https://img.shields.io/badge/Voxel51_Blog-ff6d04?style=flat)](https://voxel51.com/blog)
+[![Newsletter](https://img.shields.io/badge/Newsletter-BE5B25?logo=mail.ru&logoColor=white)](https://share.hsforms.com/1zpJ60ggaQtOoVeBqIZdaaA2ykyk)
+[![LinkedIn](https://img.shields.io/badge/In-white?style=flat&label=Linked&labelColor=blue)](https://www.linkedin.com/company/voxel51)
+[![Twitter](https://img.shields.io/badge/Twitter-000000?logo=x&logoColor=white)](https://x.com/voxel51)
+[![Medium](https://img.shields.io/badge/Medium-12100E?logo=medium&logoColor=white)](https://medium.com/voxel51)
+
+</div>
 This implements https://arxiv.org/pdf/2411.15349, a zero shot coreset selection method on unlabeled image data. Selection is based on novel redundancy and coverage metrics in a foundation-model-generated embedding space.
 
 Importantly, this method does NOT require:
@@ -16,7 +28,6 @@ Importantly, this method does NOT require:
 
 Generating zcore scores and selecting a coreset based on some threshold can be achieved in the app and programmatically.
 
-
 ### In the app
 
 ```python
@@ -31,7 +42,6 @@ session = fo.launch_app(dataset)
 
 session.wait()
 ```
-
 
 <img src="assets/operators_screenshot.png" alt="Operators panel" width="600">
 


### PR DESCRIPTION
## Summary

- Adds a consistent set of community/social badges (Discord, Hugging Face,
  Blog, Newsletter, LinkedIn, Twitter/X, Medium) to the README
- Removes any outdated Slack community references
- Badges are placed on their own row, separate from code/developer badges

This is part of an org-wide effort to ensure consistent community links
across all Voxel51 repositories.